### PR TITLE
Ensure that config is not altered if sourced dictionary changes

### DIFF
--- a/pulpo_config/pulpo_config.py
+++ b/pulpo_config/pulpo_config.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import copy
 
+
 class Config():
     __options = None
 
@@ -14,7 +15,7 @@ class Config():
             options = {}
 
         if isinstance(options, dict):
-            self.__options = copy.deepcopy (options )
+            self.__options = copy.deepcopy(options)
         elif isinstance(options, Config):
             self.__options = options.__options
 

--- a/pulpo_config/pulpo_config.py
+++ b/pulpo_config/pulpo_config.py
@@ -14,7 +14,7 @@ class Config():
             options = {}
 
         if isinstance(options, dict):
-            self.__options = options
+            self.__options = options.copy()
         elif isinstance(options, Config):
             self.__options = options.__options
 

--- a/pulpo_config/pulpo_config.py
+++ b/pulpo_config/pulpo_config.py
@@ -2,7 +2,7 @@ import typing
 import json
 import argparse
 import os
-
+import copy
 
 class Config():
     __options = None
@@ -14,7 +14,7 @@ class Config():
             options = {}
 
         if isinstance(options, dict):
-            self.__options = options.copy()
+            self.__options = copy.deepcopy (options )
         elif isinstance(options, Config):
             self.__options = options.__options
 

--- a/pulpo_config/tests/test_config.py
+++ b/pulpo_config/tests/test_config.py
@@ -212,3 +212,11 @@ class TestConfig(unittest.TestCase):
         options['k'] = '$ENV.pulpo-invalid-key'
         config = Config(options=options)
         self.assertEqual(config.get('k'), None)
+
+    def test_config_with_dict_is_immutable(self):
+        options = {'k': 'v'}
+        config = Config(options=options)
+        self.assertEqual(config.get('k'), 'v')
+
+        options['k']='v2'
+        self.assertEqual(config.get('k'), 'v')

--- a/pulpo_config/tests/test_config.py
+++ b/pulpo_config/tests/test_config.py
@@ -213,10 +213,18 @@ class TestConfig(unittest.TestCase):
         config = Config(options=options)
         self.assertEqual(config.get('k'), None)
 
-    def test_config_with_dict_is_immutable(self):
+    def test_config_with_dict_is_copy_1_level(self):
         options = {'k': 'v'}
         config = Config(options=options)
         self.assertEqual(config.get('k'), 'v')
 
         options['k']='v2'
         self.assertEqual(config.get('k'), 'v')
+
+    def test_config_with_dict_is_copy_2_level(self):
+        options = {"database": {"host": "localhost", "port": 3306}}
+        config = Config(options=options)
+        self.assertEqual(config.get('database.host'), 'localhost')
+
+        options['database']['host']='127.0.0.1'
+        self.assertEqual(config.get('database.host'), 'localhost')

--- a/pulpo_config/tests/test_config.py
+++ b/pulpo_config/tests/test_config.py
@@ -218,7 +218,7 @@ class TestConfig(unittest.TestCase):
         config = Config(options=options)
         self.assertEqual(config.get('k'), 'v')
 
-        options['k']='v2'
+        options['k'] = 'v2'
         self.assertEqual(config.get('k'), 'v')
 
     def test_config_with_dict_is_copy_2_level(self):
@@ -226,5 +226,5 @@ class TestConfig(unittest.TestCase):
         config = Config(options=options)
         self.assertEqual(config.get('database.host'), 'localhost')
 
-        options['database']['host']='127.0.0.1'
+        options['database']['host'] = '127.0.0.1'
         self.assertEqual(config.get('database.host'), 'localhost')


### PR DESCRIPTION
Consider the situation where an options dictionary is used to initialize Config.  After initialization, the underlying options dictionary changes.  The desired behavior is that the Config values are NOT impacted.

``` python
# load from options
options = {"database": {"host": "localhost", "port": 3306}}
config = Config(options=options)

# produces 'localhost'
print(config.get('database.host'))

# after loading Config, the source options is modified
options['database']['host'] = '127.0.0.1'

# desired behavior is that config is NOT impacted, so that produces 'localhost'
print(config.get('database.host'))
```

This requires making a deep copy of the source options dictionary during initialization